### PR TITLE
Script to create local ReplicaSets and read from slave machines in the replicaset

### DIFF
--- a/mongo-replset-test.sh
+++ b/mongo-replset-test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# @see https://github.com/cronnelly/mongo-replset-test
+# @see http://clock.co.uk/tech-blogs/scaling-nodejs-and-mongodb-on-joyent-cloud
+
+# dateInfo=`date --rfc-3339=seconds|sed s/\ /_/g`
+dateInfo=`date +%Y-%m-%d--%H-%M-%S|sed s/\ /_/g`
+baseDir=/tmp/mongo-replset-test-$dateInfo
+startPort=$1
+numServers=$2
+endPort=$(($startPort + $numServers - 1))
+replSetName=$3
+killCommand="kill"
+
+if [ -z $replSetName ]
+then
+	echo "Usage: $0 <StartPort> <NumServers> <SetName>"
+	exit
+fi
+
+echo "* Starting $numServers MongoDB instances under $baseDir..."
+
+mkdir -v $baseDir
+
+count=0
+configString="{_id: \"$replSetName\", members: ["
+for (( p=$startPort; p<=$endPort; p++ ))
+do
+	mkdir -v $baseDir/$p
+	mongod --replSet "$replSetName" --logpath "$baseDir/$p/mongodb.log" --dbpath "$baseDir/$p" \
+		--rest --bind_ip 127.0.0.1 --port $p --noauth --noprealloc --nojournal &
+	killCommand="$killCommand $!"
+	configString=$configString"{_id: $count, host: \"127.0.0.1:$p\"},"
+	count=$(($count + 1))
+done
+configString=$configString"]}"
+
+echo "Waiting a few seconds for daemons to start..."
+sleep 5
+echo "rs.initiate($configString);" | mongo --host 127.0.0.1 --port $startPort
+
+echo
+echo "* Done. Use the following command to kill the daemons, and clean up /tmp:"
+echo "$killCommand"
+echo "rm -r $baseDir"
+echo
+echo "* View replica set status at this URL, or by running this command:"
+echo "http://127.0.0.1:"$(($startPort + 1000))"/_replSet"
+echo "echo \"rs.status();\" | mongo --host 127.0.0.1 --port $startPort"

--- a/src/common/datastore.js
+++ b/src/common/datastore.js
@@ -23,7 +23,7 @@ var DataStore = function() {
       ddbbsettings.machines.forEach(function(machine) {
         servers.push(new mongodb.Server(machine[0], machine[1], { auto_reconnect: true }));
       });
-      var replSet = new mongodb.ReplSetServers(servers, {rs_name:ddbbsettings.replicasetName});
+      var replSet = new mongodb.ReplSetServers(servers, {rs_name:ddbbsettings.replicasetName, read_secondary: true});
 
       // Connection to MongoDB
       this.db = new mongodb.Db(ddbbsettings.ddbbname, replSet);


### PR DESCRIPTION
Adding a script to create replicasets in local machines. Add the positibility to read from secondary machines in the replicaset as advised in http://clock.co.uk/tech-blogs/scaling-nodejs-and-mongodb-on-joyent-cloud. Yay!
