### PR TITLE
Public Key stored in a simple data and not in an array or set

### DIFF
--- a/src/common/datastore.js
+++ b/src/common/datastore.js
@@ -132,7 +132,7 @@ var DataStore = function() {
     this.db.collection("apps", function(err, collection) {
       if (!err) {
         collection.update( { _id: waToken },
-          { $addToSet : { node: nodeToken, pbkbase64: pbkbase64 }},
+          { $addToSet : { node: nodeToken }, $set : { pbkbase64: pbkbase64 }},
           {safe: true, upsert: true},
           function(err,d) {
             if(!err) {


### PR DESCRIPTION
The public key is stored in a set array inside MongoDB.
Only one Pbk per webapp should be allowed so this has non-sense ;)
