### PR TITLE
Detect duplicate connection and close the newer

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -48,6 +48,7 @@ exports.errorcodes = {
     UATOKEN_NOT_FOUND: [459, "No UAtoken found for this connection!"],
     FAILED_REGISTERUA: [460, "Failed registering UAtoken"],
     ERROR_GETTING_CONNECTOR: [461, "Error getting connection object"],
+    DUPLICATE_UATOKEN: [465, "Duplicate uatoken, closing this connection"],
     COMMAND_NOT_ALLOWED: [405 , "Command not allowed in this connection"],
     UATOKEN_NOT_SENT: [462, "No UAtoken sent"],
     MESSAGETYPE_NOT_RECOGNIZED: [405, "messageType not recognized"],

--- a/src/ns_ua/connectors/connector.js
+++ b/src/ns_ua/connectors/connector.js
@@ -61,9 +61,11 @@ Connector.prototype = {
 
   unregisterUAToken: function(uatoken) {
     if(this.nodesConnectors[uatoken]) {
-      this.nodesConnectors[uatoken].getConnection().close();
+      log.debug("Connectors::unregisterUAToken --> Found on connectors, deleted");
       delete this.nodesConnectors[uatoken];
+      return;
     }
+    log.error("Connectors::unregisterUAToken --> Connector not found!!");
   }
 };
 

--- a/src/ns_ua/datamanager.js
+++ b/src/ns_ua/datamanager.js
@@ -53,37 +53,41 @@ datamanager.prototype = {
       //Might be a connection closed that has no uatoken associated (e.g. registerWA without registerUA before)
       log.debug("dataManager::unregisterNode --> This connection does not have a uatoken");
       return;
-    } else {
-      log.debug("dataManager::unregisterNode --> Removing disconnected node uatoken " + uatoken);
-      //Delete from DDBB
-      var fullyDisconnected = (Connectors.getConnectorForUAtoken(uatoken).getProtocol() !== "WS") ? 2 : 0;
-      dataStore.unregisterNode(
-        uatoken,
-        fullyDisconnected,
-        function(error) {
-          if (!error) {
-            log.debug('dataManager::unregisterNode --> Unregistered');
-          } else {
-            log.error('dataManager::unregisterNode --> There was a problem unregistering the uatoken ' + uatoken);
-          }
-        }
-      );
     }
+    log.debug("dataManager::unregisterNode --> Removing disconnected node uatoken " + uatoken);
+    //Delete from DDBB
+    var connector = Connectors.getConnectorForUAtoken(uatoken);
+    var fullyDisconnected = 0;
+    if (!connector) {
+      log.debug("dataManager::unregisterNode --> No connector found for uatoken=" + uatoken);
+    } else {
+      fullyDisconnected = (connector.getProtocol() !== "WS") ? 2 : 0;
+    }
+    dataStore.unregisterNode(
+      uatoken,
+      fullyDisconnected,
+      function(error) {
+        if (!error) {
+          log.debug('dataManager::unregisterNode --> Unregistered');
+        } else {
+          log.error('dataManager::unregisterNode --> There was a problem unregistering the uatoken ' + uatoken);
+        }
+      }
+    );
     Connectors.unregisterUAToken(uatoken);
-    log.debug("dataManager::unregisterNode --> Finished");
   },
 
   /**
    * Gets a node connector (from memory)
    */
-  getNode: function (uatoken, callback) {
-    log.debug("dataManager::getNode --> getting node from memory: " + uatoken);
+  getNodeConnector: function (uatoken) {
+    log.debug("dataManager::getNodeConnector --> getting node from memory: " + uatoken);
     var connector = Connectors.getConnectorForUAtoken(uatoken);
     if (connector) {
-      log.debug('dataManager::getNode --> Connector found: ' + uatoken);
-      return callback(connector);
+      log.debug('dataManager::getNodeConnector --> Connector found for uatoken=' + uatoken);
+      return connector;
     }
-    return callback(null);
+    return null;
   },
 
   /**

--- a/src/ns_ua/ws_server.js
+++ b/src/ns_ua/ws_server.js
@@ -41,19 +41,18 @@ function onNewMessage(message) {
   }
   log.debug("WS::Queue::onNewMessage --> Notifying node:", json.uatoken);
   log.notify("Message with id " + json.messageId + " sent to " + json.uatoken);
-  dataManager.getNode(json.uatoken, function(nodeConnector) {
-    if(nodeConnector) {
-      var notification = json.payload;
+  var nodeConnector = dataManager.getNodeConnector(json.uatoken);
+  if(nodeConnector) {
+    var notification = json.payload;
 
-      //Send the URL not the appToken
-      notification.url = helpers.getNotificationURL(notification.appToken);
-      delete notification.appToken;
-      log.debug("WS::Queue::onNewMessage --> Sending messages:", notification);
-      nodeConnector.notify(new Array(notification));
-    } else {
-      log.debug("WS::Queue::onNewMessage --> No node found");
-    }
-  });
+    //Send the URL not the appToken
+    notification.url = helpers.getNotificationURL(notification.appToken);
+    delete notification.appToken;
+    log.debug("WS::Queue::onNewMessage --> Sending messages:", notification);
+    nodeConnector.notify(new Array(notification));
+  } else {
+    log.debug("WS::Queue::onNewMessage --> No node found");
+  }
 }
 
 function onNodeRegistered(error, data, uatoken) {
@@ -314,6 +313,14 @@ server.prototype = {
             });
             return connection.close();
           }
+          //Check if we have an old connector, if so, close this connection, leave the older
+          var connector = dataManager.getNodeConnector(query.data.uatoken);
+          if (connector) {
+            log.debug("WS::onWSMessage --> Second WS opened for uatoken=" +  query.data.uatoken + ". Bad idea, closing");
+            //Close new
+            connection.close();
+            return;
+          }
           log.debug("WS:onWSMessage --> Accepted uatoken=" + query.data.uatoken);
           connection.uatoken = query.data.uatoken;
         } else if (!connection.uatoken) {
@@ -335,7 +342,7 @@ server.prototype = {
 
           case "unregisterUA":
             log.debug("WS::onWSMessage::unregisterUA -> UA unregistration message");
-            dataManager.unregisterNode(connection.uatoken);
+            connection.close();
             break;
 
           case "registerWA":


### PR DESCRIPTION
This makes `getNodeConnector` synchronous (no neccesary to be async since implies no I/O).
`unregisterNode` is right now only responsibility of WebSocket `close` event, so we do not try to close and delete, at least, twice.
