### PR TITLE
Fix #224. Handle correctly recovery protocol

### DIFF
--- a/src/ns_ua/datamanager.js
+++ b/src/ns_ua/datamanager.js
@@ -133,9 +133,7 @@ datamanager.prototype = {
    * Recover a list of WA associated to a UA
    */
   getApplicationsForUA: function (uaid, callback) {
-    // Recover from the persistent storage
-    var callbackParam = false;
-    dataStore.getApplicationsForUA(uaid, callback, callbackParam);
+    dataStore.getApplicationsForUA(uaid, callback);
   },
 
   /**


### PR DESCRIPTION
For the attribute `channelIDs` sent on `hello` message:
1. If channelIDs is `undefined` or `null` --> it ignores the attribute
2. If channelIDs is an empty array --> it clears all registration for the node
3. For each element on `channelIDs`:
   - If the element is on the registered apps for the given node: do nothing
   - If the element is not on the registered apps for the given node: unregister it
   - If there are pending elements on the `channelIDs` array, register them (with the registration message)
