### PR TITLE
Fix problem when disconnecting a node requested by a process that do not own the node

### DIFF
--- a/src/common/datastore.js
+++ b/src/common/datastore.js
@@ -148,7 +148,7 @@ var DataStore = function() {
   /**
    * Unregister a node
    */
-   this.unregisterNode = function(uaid, fullyDisconnected, callback) {
+   this.unregisterNode = function(uaid, queue, fullyDisconnected, callback) {
     this.db.collection('nodes', function(err, collection) {
       callback = helpers.checkCallback(callback);
       if (err) {
@@ -160,7 +160,10 @@ var DataStore = function() {
         return;
       }
       collection.findAndModify(
-        { _id: uaid },
+        {
+          _id: uaid,
+          si: queue
+        },
         [],
         {
           $set: {

--- a/src/ns_ua/datamanager.js
+++ b/src/ns_ua/datamanager.js
@@ -69,6 +69,7 @@ datamanager.prototype = {
       }
       dataStore.unregisterNode(
         uaid,
+        connector.getServer(),
         fullyDisconnected,
         function(error) {
           if (!error) {


### PR DESCRIPTION
This uses the queue of the process that has requested the disconnection of the node.

If the node is connected to another server, it MUST has changed the queue, so any try to disconnect a node made by other instance that do not own the actual state of the node should be rejected.
